### PR TITLE
WIP - Remove hard coded variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,27 @@
+# Variables needed for this script are:
+
+# Case 1: Stored on Travis Settings
+  # For all environments:
+    # - DOCKER_CI_REPO_NAME <-- do we need that?
+    # - DOCKER_USERNAME
+    # - DOCKER_PASSWORD
+
+  #For dev environment:
+    # - AWS_ACCOUNT_USER_ID_DEV
+    # - AWS_ACCOUNT_SECRET_DEV
+
+  #For Demo environment:
+    # - AWS_ACCOUNT_USER_ID_DEMO
+    # - AWS_ACCOUNT_SECRET_DEMO
+
+  #For Prod environment:
+    # - AWS_ACCOUNT_USER_ID_PROD
+    # - AWS_ACCOUNT_SECRET_PROD
+
+# Case 2: Created when Travis CI runs ??
+    # - TRAVIS_TAG
+    # - TRAVIS_OS_NAME
+
 sudo: required
 language: go
 
@@ -13,7 +37,7 @@ install:
   - sudo apt-get install jq -y
 
 after_success:
-  - test -n "$TRAVIS_TAG" && docker login -u=uneetci -p="$DOCKER_PASSWORD"
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 script:
   - go test -v ./...
@@ -21,21 +45,21 @@ script:
 deploy:
   # dev
   - provider: script
-    script: cd web && make
+    script: cd web && AWS_ACCESS_KEY_ID=$AWS_ACCOUNT_USER_ID_DEV AWS_SECRET_ACCESS_KEY=$AWS_ACCOUNT_SECRET_DEV ./deploy.sh dev
     skip_cleanup: true
     on:
       branch: master
   # demo
   - provider: script
     script:
-      cd web && AWS_ACCESS_KEY_ID=$AWS_915001051872_ID AWS_SECRET_ACCESS_KEY=$AWS_915001051872_SECRET make demo
+      cd web && AWS_ACCESS_KEY_ID=$AWS_ACCOUNT_USER_ID_DEMO AWS_SECRET_ACCESS_KEY=$AWS_ACCOUNT_SECRET_DEMO ./deploy.sh demo
     skip_cleanup: true
     on:
       tags: true
   # production
   - provider: script
     script:
-      cd web && AWS_ACCESS_KEY_ID=$AWS_192458993663_ID AWS_SECRET_ACCESS_KEY=$AWS_192458993663_SECRET make prod
+      cd web && AWS_ACCESS_KEY_ID=$AWS_ACCOUNT_USER_ID_PROD AWS_SECRET_ACCESS_KEY=$AWS_ACCOUNT_SECRET_PROD ./deploy.sh prod
     skip_cleanup: true
     on:
       tags: true

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,24 @@
-REGION:=ap-southeast-1
-
 dev:
 	go generate
 	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env dev deploy
-
-demo:
-	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env demo deploy
-
-demologs:
-	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env demo logs -f
-
-prod:
-	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env prod deploy
+	apex -r $(AWS_REGION) --env dev deploy
 
 devlogs:
 	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env dev logs -f
+	apex -r $(AWS_REGION) --env dev logs -f
+
+demo:
+	@echo $$AWS_ACCESS_KEY_ID
+	apex -r $(AWS_REGION) --env demo deploy
+
+demologs:
+	@echo $$AWS_ACCESS_KEY_ID
+	apex -r $(AWS_REGION) --env demo logs -f
+
+prod:
+	@echo $$AWS_ACCESS_KEY_ID
+	apex -r $(AWS_REGION) --env prod deploy
 
 prodlogs:
 	@echo $$AWS_ACCESS_KEY_ID
-	apex -r $(REGION) --env prod logs -f
+	apex -r $(AWS_REGION) --env prod logs -f

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ On [Docker Hub](https://hub.docker.com/r/uneet/invite) for [local development](h
 
 # Different environments
 
+##################################
+# This needs to be reviewed <-- these are hardcoded values that are environment specific.
+##################################
+
 This is codified over at: https://github.com/unee-t/env
 
 ## dev environment
@@ -25,6 +29,10 @@ This is codified over at: https://github.com/unee-t/env
 * AWS account id: 192458993663
 * profile: uneet-prod
 * https://invite.unee-t.com
+
+##################################
+# END This needs to be reviewed
+##################################
 
 # Test plan
 

--- a/asset_dev.gen.go
+++ b/asset_dev.gen.go
@@ -24,7 +24,9 @@ func (a asset) init() asset {
 
 func (a asset) importPath() string {
 	// filled at code gen time
+// This is a hardcoded variable <-- should be moved to aws-env.[stage] file
 	return "github.com/unee-t/invite"
+// END This is a hardcoded variable
 }
 
 func (a asset) Open() (*os.File, error) {

--- a/asset_dev.gen.go
+++ b/asset_dev.gen.go
@@ -24,7 +24,8 @@ func (a asset) init() asset {
 
 func (a asset) importPath() string {
 	// filled at code gen time
-// This is a hardcoded variable <-- should be moved to aws-env.[stage] file
+// This is a hardcoded variable <-- should be moved
+// WARNING - we need to understand if it's safe to change this...
 	return "github.com/unee-t/invite"
 // END This is a hardcoded variable
 }

--- a/aws-env.dev
+++ b/aws-env.dev
@@ -1,0 +1,36 @@
+#!/bin/bash
+## This file stores all environment variables for the DEV environment for this repo
+
+# First, we create a procedure to retrieve the variables from the AWS parameter store
+# Make sure to 
+#   - configure your AWS CLI accordingly
+#   - update the profile you need to use to access these variables if needed
+
+    getparam () {
+        #When we run this command, we get the issue: no matches found: Parameters[0].Value.
+        #aws --profile ins-dev ssm get-parameters --names "$1" --with-decryption --query Parameters[0].Value --output text
+        #So I changed the command like below, and It works!
+        aws --profile ins-dev ssm get-parameters --names "$1" --with-decryption  --output text | awk '{print $6}'
+    }
+    
+# We prepare the hardcoded variables that we will need to deploy what's needed
+
+    export STAGE=dev
+
+# Variables that are maintained in the AWS parameter store for the environment:
+
+    export AWS_REGION=$(getparam DEFAULT_REGION)
+    export DEFAULT_SECURITY_GROUP=$(getparam DEFAULT_SECURITY_GROUP)
+    export PRIVATE_SUBNET_1=$(getparam PRIVATE_SUBNET_1)
+    export PRIVATE_SUBNET_2=$(getparam PRIVATE_SUBNET_2)
+    export PRIVATE_SUBNET_3=$(getparam PRIVATE_SUBNET_3)
+    export MYSQL_PASSWORD=$(getparam UNTEDB_ROOT_PASS)
+    export MYSQL_USER=$(getparam UNTEDB_ROOT_USER)
+    export MYSQL_HOST=$(getparam UNTEDB_HOST)
+    export UNTE_DB_NAME=$(getparam UNTE_DB_NAME)
+    export S3_BUCKET_NAME=$(getparam S3_BUCKET_NAME)
+
+# Variables that are built from other variables:
+
+    export AWS_PROFILE=$(getparam INSTALLATION_ID)-$STAGE
+    export PRIVATE_SUBNETS=$PRIVATE_SUBNET_1,$PRIVATE_SUBNET_2,$PRIVATE_SUBNET_3

--- a/aws-env.dev
+++ b/aws-env.dev
@@ -20,15 +20,11 @@
 # Variables that are maintained in the AWS parameter store for the environment:
 
     export AWS_REGION=$(getparam DEFAULT_REGION)
+
     export DEFAULT_SECURITY_GROUP=$(getparam DEFAULT_SECURITY_GROUP)
     export PRIVATE_SUBNET_1=$(getparam PRIVATE_SUBNET_1)
     export PRIVATE_SUBNET_2=$(getparam PRIVATE_SUBNET_2)
     export PRIVATE_SUBNET_3=$(getparam PRIVATE_SUBNET_3)
-    export MYSQL_PASSWORD=$(getparam UNTEDB_ROOT_PASS)
-    export MYSQL_USER=$(getparam UNTEDB_ROOT_USER)
-    export MYSQL_HOST=$(getparam UNTEDB_HOST)
-    export UNTE_DB_NAME=$(getparam UNTE_DB_NAME)
-    export S3_BUCKET_NAME=$(getparam S3_BUCKET_NAME)
 
 # Variables that are built from other variables:
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#This script is created to deploy lambda2sqs 
+#Variable is the environment like dev, demo or prod
+#To run this script, run this command: ./deploy.sh [STAGE] where STAGE is dev, demo or prod
+#
+#Step 1: Setup the parameters
+export INSTALLATION_ID=ins
+export AWS_PROFILE=$INSTALLATION_ID-$1
+source aws-env.$1
+
+#Step 2: Run Makefile.
+#make $1
+
+echo $AWS_PROFILE

--- a/gentest/main.go
+++ b/gentest/main.go
@@ -6,7 +6,9 @@ import (
 	"io/ioutil"
 
 	uuid "github.com/satori/go.uuid"
+// This is a hardcoded variable <-- should be moved
 	"github.com/unee-t/invite"
+// END This is a hardcoded variable
 )
 
 type SQSBatch struct {

--- a/gentest/queue.sh
+++ b/gentest/queue.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 test -f "$1" || exit
+# This is a hardcoded variable <-- should be moved
 QUEUE=https://sqs.ap-southeast-1.amazonaws.com/812644853088/invites
 #QUEUE=https://sqs.ap-southeast-1.amazonaws.com/915001051872/invites
+# END This is a hardcoded variable
 echo Attempting to put $1 onto $QUEUE
+# This is a hardcoded variable <-- should be moved
 aws --profile uneet-dev sqs send-message-batch \
+# END This is a hardcoded variable
 	--queue-url $QUEUE \
 	--entries file://$1

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -7,6 +7,8 @@ build:
 
 dockers:
   - image_templates:
+# This is a hardcoded variable <-- should be moved    
       - uneet/invite
+# END This is a hardcoded variable
     build_flag_templates:
       - "--label=org.label-schema.version={{.Version}}"

--- a/project.demo.json
+++ b/project.demo.json
@@ -1,18 +1,26 @@
 {
   "name": "invitefromqueue",
+  # This is a hardcoded variable that is environment dependant  
   "profile": "uneet-demo",
+  # END This is a hardcoded variable that is environment dependant
   "memory": 128,
   "timeout": 60,
+  # This is a hardcoded variable that is environment dependant  
   "role": "arn:aws:iam::915001051872:role/invitefromqueue_lambda_function",
+  # END This is a hardcoded variable that is environment dependant
   "environment": {},
   "vpc": {
     "subnets": [
+      # This is a hardcoded variable that is environment dependant  
       "subnet-0bdef9ce0d0e2f596",
       "subnet-091e5c7d98cd80c0d",
       "subnet-0fbf1eb8af1ca56e3"
+      # END This is a hardcoded variable that is environment dependant
     ],
     "securityGroups": [
+      # This is a hardcoded variable that is environment dependant  
       "sg-6f66d316"
+      # END This is a hardcoded variable that is environment dependant
     ]
   }
 }

--- a/project.dev.json
+++ b/project.dev.json
@@ -1,18 +1,26 @@
 {
   "name": "invitefromqueue",
+  # This is a hardcoded variable that is environment dependant
   "profile": "uneet-dev",
+  # END This is a hardcoded variable that is environment dependant
   "memory": 128,
   "timeout": 60,
+  # This is a hardcoded variable that is environment dependant
   "role": "arn:aws:iam::812644853088:role/invitefromqueue_lambda_function",
+  # END This is a hardcoded variable that is environment dependant
   "environment": {},
   "vpc": {
     "subnets": [
+      # This is a hardcoded variable that is environment dependant
       "subnet-0ff046ccc4e3b6281",
       "subnet-0938728dfb344b970",
       "subnet-0e123bd457c082cff"
+      # END This is a hardcoded variable that is environment dependant
     ],
     "securityGroups": [
+      # This is a hardcoded variable that is environment dependant
       "sg-66390301"
+      # END This is a hardcoded variable that is environment dependant
     ]
   }
 }

--- a/project.prod.json
+++ b/project.prod.json
@@ -1,18 +1,26 @@
 {
   "name": "invitefromqueue",
+  # This is a hardcoded variable that is environment dependant
   "profile": "uneet-prod",
+  # END This is a hardcoded variable that is environment dependant
   "memory": 128,
   "timeout": 60,
+  # This is a hardcoded variable that is environment dependant
   "role": "arn:aws:iam::192458993663:role/invitefromqueue_lambda_function",
+  # END This is a hardcoded variable that is environment dependant
   "environment": {},
   "vpc": {
     "subnets": [
+      # This is a hardcoded variable that is environment dependant
       "subnet-0df289b6d96447a84",
       "subnet-0e41c71ad02ee7e99",
       "subnet-01cb9ee064743ac56"
+      # END This is a hardcoded variable that is environment dependant
     ],
     "securityGroups": [
+      # This is a hardcoded variable that is environment dependant
       "sg-9f5b5ef8"
+      # END This is a hardcoded variable that is environment dependant
     ]
   }
 }

--- a/sqs/delete
+++ b/sqs/delete
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This is a hardcoded variable <-- should be moved
 aws --profile uneet-dev sqs delete-message --queue-url https://sqs.ap-southeast-1.amazonaws.com/812644853088/invites \
+# END This is a hardcoded variable
 	--receipt-handle "$1"
 

--- a/sqs/messages
+++ b/sqs/messages
@@ -1,2 +1,4 @@
 #!/bin/bash
+# This is a hardcoded variable <-- should be moved
 aws --profile uneet-dev sqs get-queue-attributes --queue-url https://sqs.ap-southeast-1.amazonaws.com/812644853088/invites --attribute-names ApproximateNumberOfMessages
+# This is a hardcoded variable

--- a/sqs/put
+++ b/sqs/put
@@ -1,3 +1,5 @@
 #!/bin/bash
 test "$1" || exit
+# This is a hardcoded variable <-- should be moved
 aws --profile uneet-dev sqs send-message --queue-url https://sqs.ap-southeast-1.amazonaws.com/812644853088/invites --message-body "$1"
+# END This is a hardcoded variable

--- a/sqs/receive
+++ b/sqs/receive
@@ -1,2 +1,4 @@
 #!/bin/bash
+# This is a hardcoded variable <-- should be moved
 aws --profile uneet-dev sqs receive-message --queue-url https://sqs.ap-southeast-1.amazonaws.com/812644853088/invites
+# END This is a hardcoded variable

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,3 +1,4 @@
+# This is a hardcoded variable <-- should be moved
 DEVUPJSON = '.profile |= "uneet-dev" \
 		  |.stages.production |= (.domain = "invite.dev.unee-t.com" | .zone = "dev.unee-t.com") \
 		  | .actions[0].emails |= ["kai.hendry+invitedev@unee-t.com"] \
@@ -15,6 +16,7 @@ PRODUPJSON = '.profile |= "uneet-prod" \
 		  | .actions[0].emails |= ["kai.hendry+inviteprod@unee-t.com"] \
 		  | .lambda.vpc.subnets |= [ "subnet-0df289b6d96447a84", "subnet-0e41c71ad02ee7e99", "subnet-01cb9ee064743ac56" ] \
 		  | .lambda.vpc.security_groups |= [ "sg-9f5b5ef8" ]'
+# END This is a hardcoded variable
 
 dev:
 	@echo $$AWS_ACCESS_KEY_ID
@@ -32,13 +34,21 @@ prod:
 	up deploy production
 
 testdev:
+# This is a hardcoded variable <-- should be moved
 	curl -H "Authorization: Bearer $(shell aws --profile uneet-dev ssm get-parameters --names API_ACCESS_TOKEN --with-decryption --query Parameters[0].Value --output text)" https://invite.dev.unee-t.com/version
+# END This is a hardcoded variable
 
 testdemo:
+# This is a hardcoded variable <-- should be moved
 	curl -H "Authorization: Bearer $(shell aws --profile uneet-demo ssm get-parameters --names API_ACCESS_TOKEN --with-decryption --query Parameters[0].Value --output text)" https://invite.demo.unee-t.com/version
+# END This is a hardcoded variable
 
 testprod:
+# This is a hardcoded variable <-- should be moved
 	curl -H "Authorization: Bearer $(shell aws --profile uneet-prod ssm get-parameters --names API_ACCESS_TOKEN --with-decryption --query Parameters[0].Value --output text)" https://invite.unee-t.com/version
+# This is a hardcoded variable
 
 testping:
+# This is a hardcoded variable <-- should be moved
 	curl -i -H "Authorization: Bearer $(shell aws --profile uneet-prod ssm get-parameters --names API_ACCESS_TOKEN --with-decryption --query Parameters[0].Value --output text)" https://invite.unee-t.com/health_check
+# This is a hardcoded variable

--- a/web/main.go
+++ b/web/main.go
@@ -8,7 +8,9 @@ import (
 	"github.com/apex/log"
 	jsonloghandler "github.com/apex/log/handlers/json"
 	"github.com/apex/log/handlers/text"
+	// This is a hardcoded variable <-- should be moved
 	"github.com/unee-t/invite"
+	// END This is a hardcoded variable
 )
 
 func init() {

--- a/web/main_test.go
+++ b/web/main_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/apex/log"
 	uuid "github.com/satori/go.uuid"
+	// This is a hardcoded variable <-- should be moved
 	"github.com/unee-t/invite"
+	// END This is a hardcoded variable
 )
 
 func TestPOST500(t *testing.T) {

--- a/web/up.json.in
+++ b/web/up.json.in
@@ -1,17 +1,23 @@
 {
   "name": "processinvitations",
+# This is a hardcoded variable <-- should be moved
   "profile": "uneet-dev",
+# END This is a hardcoded variable
   "stages": {
     "production": {
+# This is a hardcoded variable <-- should be moved
       "domain": "invite.dev.unee-t.com",
       "zone": "dev.unee-t.com"
+# END This is a hardcoded variable
     }
   },
   "proxy": {
     "timeout": 25
   },
   "regions": [
+# This is a hardcoded variable <-- should be moved
     "ap-southeast-1"
+# END This is a hardcoded variable
   ],
   "error_pages": {
     "disable": true
@@ -39,7 +45,9 @@
       "name": "email.backend",
       "type": "email",
       "emails": [
+# This is a hardcoded variable <-- should be moved
         "kai.hendry+invite@unee-t.com"
+# END This is a hardcoded variable
       ]
     }
   ],


### PR DESCRIPTION
This PR is to standardize how we store environment-specific parameters.

We need to store environment-specific parameters more efficiently than the current implementation where environment-specific variables are hardcoded in 20 different files.

Ideally, environment variables should be maintained in only 3 places:
- AWS parameter store
- aws-env.[stage] file
- Travis-CI environment variables